### PR TITLE
Modify flyteconsole for default filters and publish

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log
 # generated data
 certificate
 .env
+.direnv

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -15,11 +15,37 @@ echo -e "${GREEN}Starting build and push process for flyteconsole...${NC}"
 
 # Login to ECR
 echo -e "${GREEN}Logging into ECR...${NC}"
-aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+
+# Work around for macOS credential store issues
+# First, get the ECR login token
+ECR_TOKEN=$(aws ecr get-login-password --region ${REGION})
+
+if [ -z "$ECR_TOKEN" ]; then
+    echo -e "${RED}Failed to get ECR login token. Make sure AWS CLI is configured.${NC}"
+    exit 1
+fi
+
+# Use the token to login, explicitly avoiding credential store
+echo "$ECR_TOKEN" | docker login --username AWS --password-stdin ${ECR_REGISTRY} 2>/dev/null
 
 if [ $? -ne 0 ]; then
-    echo -e "${RED}Failed to login to ECR. Make sure AWS CLI is configured.${NC}"
-    exit 1
+    echo -e "${RED}Failed to login to ECR. Trying alternative method...${NC}"
+    # Alternative: Create a temporary config without credential store
+    DOCKER_CONFIG=$(mktemp -d)
+    echo '{"auths":{}}' > "$DOCKER_CONFIG/config.json"
+    echo "$ECR_TOKEN" | DOCKER_CONFIG="$DOCKER_CONFIG" docker login --username AWS --password-stdin ${ECR_REGISTRY}
+
+    if [ $? -ne 0 ]; then
+        echo -e "${RED}Failed to login to ECR even with alternative method.${NC}"
+        rm -rf "$DOCKER_CONFIG"
+        exit 1
+    fi
+
+    # Export the temporary config for subsequent commands
+    export DOCKER_CONFIG="$DOCKER_CONFIG"
+    echo -e "${GREEN}Successfully logged in using alternative method.${NC}"
+else
+    echo -e "${GREEN}Successfully logged into ECR.${NC}"
 fi
 
 # Build the Docker image
@@ -28,6 +54,7 @@ docker build -t ${ECR_REPOSITORY}:${IMAGE_TAG} .
 
 if [ $? -ne 0 ]; then
     echo -e "${RED}Failed to build Docker image.${NC}"
+    [ -n "$DOCKER_CONFIG" ] && [ "$DOCKER_CONFIG" != "$HOME/.docker" ] && rm -rf "$DOCKER_CONFIG"
     exit 1
 fi
 
@@ -41,8 +68,12 @@ docker push ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
 
 if [ $? -ne 0 ]; then
     echo -e "${RED}Failed to push image to ECR.${NC}"
+    [ -n "$DOCKER_CONFIG" ] && [ "$DOCKER_CONFIG" != "$HOME/.docker" ] && rm -rf "$DOCKER_CONFIG"
     exit 1
 fi
+
+# Clean up temporary Docker config if we created one
+[ -n "$DOCKER_CONFIG" ] && [ "$DOCKER_CONFIG" != "$HOME/.docker" ] && rm -rf "$DOCKER_CONFIG"
 
 echo -e "${GREEN}Successfully pushed ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}${NC}"
 echo -e "${GREEN}Build and push completed!${NC}"

--- a/build-and-push.sh
+++ b/build-and-push.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# ECR repository details
+ECR_REGISTRY="472386928882.dkr.ecr.us-west-2.amazonaws.com"
+ECR_REPOSITORY="flyteconsole"
+IMAGE_TAG="latest"
+REGION="us-west-2"
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}Starting build and push process for flyteconsole...${NC}"
+
+# Login to ECR
+echo -e "${GREEN}Logging into ECR...${NC}"
+aws ecr get-login-password --region ${REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Failed to login to ECR. Make sure AWS CLI is configured.${NC}"
+    exit 1
+fi
+
+# Build the Docker image
+echo -e "${GREEN}Building Docker image...${NC}"
+docker build -t ${ECR_REPOSITORY}:${IMAGE_TAG} .
+
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Failed to build Docker image.${NC}"
+    exit 1
+fi
+
+# Tag the image for ECR
+echo -e "${GREEN}Tagging image for ECR...${NC}"
+docker tag ${ECR_REPOSITORY}:${IMAGE_TAG} ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
+
+# Push the image to ECR
+echo -e "${GREEN}Pushing image to ECR...${NC}"
+docker push ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}
+
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Failed to push image to ECR.${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Successfully pushed ${ECR_REGISTRY}/${ECR_REPOSITORY}:${IMAGE_TAG}${NC}"
+echo -e "${GREEN}Build and push completed!${NC}"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753250450,
+        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Flyteconsole development environment with AWS CLI and ECR credential helper";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # AWS tools
+            awscli2
+            amazon-ecr-credential-helper
+
+            # Additional tools you might need
+            docker
+            docker-compose
+            jq
+            curl
+
+            # Node.js for flyteconsole development
+            nodejs_22
+            yarn
+
+            # Other useful tools
+            git
+            which
+          ];
+
+          shellHook = ''
+            echo "Flyteconsole development environment loaded!"
+            echo "Available tools:"
+            echo "  - AWS CLI v2"
+            echo "  - Amazon ECR credential helper"
+            echo "  - Docker & Docker Compose"
+            echo "  - Node.js & Yarn"
+
+            # Set up Docker credential helper for ECR
+            if [ ! -f ~/.docker/config.json ]; then
+              mkdir -p ~/.docker
+              echo '{"credsStore": "ecr-login"}' > ~/.docker/config.json
+            else
+              # Check if ECR credential helper is already configured
+              if ! grep -q "ecr-login" ~/.docker/config.json; then
+                echo "Note: Docker config exists but ECR credential helper is not configured."
+                echo "You may want to add '\"credsStore\": \"ecr-login\"' to ~/.docker/config.json"
+              fi
+            fi
+          '';
+        };
+      });
+}

--- a/packages/oss-console/src/components/Executions/filters/useExecutionFiltersState.ts
+++ b/packages/oss-console/src/components/Executions/filters/useExecutionFiltersState.ts
@@ -33,7 +33,7 @@ export function useWorkflowExecutionFiltersState() {
   return useExecutionFiltersState([
     useMultiFilterState({
       options: workflowExecutionStatusFilters,
-      defaultValue: [],
+      defaultValue: ['running'], // Default to showing "In Progress" executions
       filterKey: 'phase',
       label: filterLabels.status,
       listHeader: 'Filter By',

--- a/packages/oss-console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts
+++ b/packages/oss-console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts
@@ -31,7 +31,7 @@ export function useOnlyMyExecutionsFilterState({
   const isFlagEnabled = useFeatureFlag(FeatureFlag.OnlyMine);
   const onlyMineExecutionsSelectedValue = useOnlyMineSelectedValue(OnlyMyFilter.OnlyMyExecutions);
   const [onlyMyExecutionsValue, setOnlyMyExecutionsValue] = useState<boolean>(
-    isFlagEnabled ? onlyMineExecutionsSelectedValue : initialValue ?? false, // if flag is enable let's use the value from only mine
+    isFlagEnabled ? onlyMineExecutionsSelectedValue : initialValue ?? true, // Default to true to show only my executions
   );
   const defaultIsFilterDisabled = !apiContext;
 


### PR DESCRIPTION
## _Read then delete this section_

_- Make sure to use a concise title for the pull-request._

_- Use #patch, #minor or #major in the pull-request title to bump the corresponding version. Otherwise, the patch version
will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)_

# TL;DR
This PR sets the "In Progress" status filter and the "Only my executions" checkbox to be selected by default on all execution list pages in Flyte Console.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The Flyte Console execution list now defaults to showing "In Progress" executions and filtering by "Only my executions".

*   **"In Progress" Filter**: Modified `packages/oss-console/src/components/Executions/filters/useExecutionFiltersState.ts` to set `defaultValue: ['running']` for the status filter. This ensures "In Progress" executions are shown by default.
*   **"Only My Executions" Default**: Modified `packages/oss-console/src/components/Executions/filters/useOnlyMyExecutionsFilterState.ts` to set the default value to `true` when no initial value is provided.

These changes improve the default user experience by immediately showing relevant, active executions. Users can still clear or change these filters as needed.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_

---

[Slack Thread](https://exa-labs-inc.slack.com/archives/C06SWF577MX/p1753383368453089?thread_ts=1753383368.453089&cid=C06SWF577MX) • [Open in Web](https://www.cursor.com/agents?id=bc-705e4948-a723-4929-abf3-f8a643b3848e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-705e4948-a723-4929-abf3-f8a643b3848e)