### PR TITLE
feat(ci): Add ECR build and push workflow

### DIFF
--- a/.github/workflows/ecr-push.yml
+++ b/.github/workflows/ecr-push.yml
@@ -1,0 +1,77 @@
+name: Build & Push to ECR
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: exa-labs/flyteconsole
+
+jobs:
+  build_and_push:
+    name: Build & Push to ECR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Determine image tags
+        id: tags
+        run: |
+          REGISTRY="${{ steps.login-ecr.outputs.registry }}"
+          REPO="${{ env.ECR_REPOSITORY }}"
+          
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # Tag push - use the tag version
+            VERSION="${GITHUB_REF#refs/tags/}"
+            echo "tags=${REGISTRY}/${REPO}:${VERSION},${REGISTRY}/${REPO}:latest" >> "$GITHUB_OUTPUT"
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.ref }}" == refs/heads/master ]]; then
+            # Push to master - use commit SHA and latest
+            echo "tags=${REGISTRY}/${REPO}:master-${{ github.sha }},${REGISTRY}/${REPO}:master" >> "$GITHUB_OUTPUT"
+            echo "push=true" >> "$GITHUB_OUTPUT"
+          else
+            # PR - build but don't push
+            echo "tags=${REGISTRY}/${REPO}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.tags.outputs.push }}
+          tags: ${{ steps.tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to build and push flyteconsole Docker images to AWS ECR (`472386928882.dkr.ecr.us-west-2.amazonaws.com/exa-labs/flyteconsole`).

**Trigger behavior:**
- **Tags (v*)**: Pushes `{version}` and `latest` tags
- **Master push**: Pushes `master-{sha}` and `master` tags  
- **PRs**: Builds only (no push) for validation

Uses AWS OIDC authentication and multi-platform builds (amd64/arm64).

## Review & Testing Checklist for Human
- [ ] **Configure `AWS_ROLE_TO_ASSUME` secret** in repo settings pointing to `github-actions-role` ARN
- [ ] **Merge monorepo PR #8839** to create the ECR repository
- [ ] **Add `repo:exa-labs/flyteconsole:*`** to github-actions-role OIDC trust policy (separate monorepo PR needed - not yet created)
- [ ] **Verify fork protection is not needed** - workflow doesn't have `github.event.pull_request.head.repo.fork == false` check, so fork PRs will fail on AWS auth step (may be acceptable)
- [ ] **Test end-to-end** after dependencies are in place: push to master or create a tag to verify image appears in ECR

### Notes
- This workflow will fail until the IAM trust policy is updated to include this repo
- The existing `checks.yml` workflow uses upstream flytetools for Docker builds to ghcr.io - this new workflow is separate and pushes to private ECR
- Session: https://app.devin.ai/sessions/130c72d1c584498db82dc42ac8ccdafa
- Requested by: @Carlos-Marques